### PR TITLE
fix: add attribute names to linked partner logos

### DIFF
--- a/newspack-media-partners.php
+++ b/newspack-media-partners.php
@@ -208,16 +208,16 @@ class Newspack_Media_Partners {
 			$partner_html .= '';
 			if ( $partner_logo ) {
 				$logo_html = '';
-		 		$logo_atts = wp_get_attachment_image_src( $partner_logo, 'full' );
-		 		if ( $logo_atts ) {
-		 			$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_attr( $logo_atts[0] ) . '" /></figure>';
-		 		}
+				$logo_atts = wp_get_attachment_image_src( $partner_logo, 'full' );
+				if ( $logo_atts ) {
+					$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_attr( $logo_atts[0] ) . '" alt="' . esc_attr( $partner->name ) . '" /></figure>';
+				}
 
-		 		if ( $logo_html && $partner_url ) {
-		 			$logo_html = '<a href="' . esc_url( $partner_url ) . '">' . $logo_html . '</a>';
-		 		}
+				if ( $logo_html && $partner_url ) {
+					$logo_html = '<a href="' . esc_url( $partner_url ) . '">' . $logo_html . '</a>';
+				}
 
-		 		$partner_html .= $logo_html;
+				$partner_html .= $logo_html;
 			}
 
 			$partner_name = $partner->name;
@@ -280,7 +280,7 @@ class Newspack_Media_Partners {
 			$partner_url      = esc_url( get_term_meta( $partner->term_id, 'partner_homepage_url', true ) );
 			$image            = '';
 			if ( $partner_image_id ) {
-				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ] );
+				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ], false, [ 'alt' => esc_attr( $partner->name ) ] );
 				if ( $image && $partner_url ) {
 					$image = '<a href="' . $partner_url . '" target="_blank">' . $image . '</a>';
 				}

--- a/newspack-media-partners.php
+++ b/newspack-media-partners.php
@@ -209,11 +209,15 @@ class Newspack_Media_Partners {
 			if ( $partner_logo ) {
 				$logo_html = '';
 				$logo_atts = wp_get_attachment_image_src( $partner_logo, 'full' );
-				$logo_alt  = sprintf(
-					/* translators: replaced with the name of the Media Partner */
-					__( 'Website for %s', 'newspack-media-partners' ),
-					$partner->name
-				);
+				$logo_alt  = $partner->name;
+				
+				if ( $partner_url ) {
+					$logo_alt  = sprintf(
+						/* translators: replaced with the name of the Media Partner */
+						__( 'Website for %s', 'newspack-media-partners' ),
+						$partner->name
+					);
+				}
 
 				if ( $logo_atts ) {
 					$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_attr( $logo_atts[0] ) . '" alt="' . esc_attr( $logo_alt ) . '" /></figure>';
@@ -285,11 +289,16 @@ class Newspack_Media_Partners {
 			$partner_image_id = get_term_meta( $partner->term_id, 'logo', true );
 			$partner_url      = esc_url( get_term_meta( $partner->term_id, 'partner_homepage_url', true ) );
 			$image            = '';
-			$image_alt        = sprintf(
-									/* translators: replaced with the name of the Media Partner */
-									__( 'Website for %s', 'newspack-media-partners' ),
-									$partner->name
-								);
+			$image_alt        = $partner->name;
+			
+			if ( $partner_url ) {
+				$image_alt = sprintf(
+					/* translators: replaced with the name of the Media Partner */
+					__( 'Website for %s', 'newspack-media-partners' ),
+					$partner->name
+				);
+			}
+
 			if ( $partner_image_id ) {
 				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ], false, [ 'alt' => esc_attr( $image_alt ) ] );
 				if ( $image && $partner_url ) {

--- a/newspack-media-partners.php
+++ b/newspack-media-partners.php
@@ -209,8 +209,14 @@ class Newspack_Media_Partners {
 			if ( $partner_logo ) {
 				$logo_html = '';
 				$logo_atts = wp_get_attachment_image_src( $partner_logo, 'full' );
+				$logo_alt  = sprintf(
+					/* translators: replaced with the name of the Media Partner */
+					__( 'Website for %s', 'newspack-media-partners' ),
+					$partner->name
+				);
+
 				if ( $logo_atts ) {
-					$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_attr( $logo_atts[0] ) . '" alt="' . esc_attr( $partner->name ) . '" /></figure>';
+					$logo_html = '<figure class="wp-block-image newspack-media-partners media-partner"><img class="aligncenter" src="' . esc_attr( $logo_atts[0] ) . '" alt="' . esc_attr( $logo_alt ) . '" /></figure>';
 				}
 
 				if ( $logo_html && $partner_url ) {
@@ -279,8 +285,13 @@ class Newspack_Media_Partners {
 			$partner_image_id = get_term_meta( $partner->term_id, 'logo', true );
 			$partner_url      = esc_url( get_term_meta( $partner->term_id, 'partner_homepage_url', true ) );
 			$image            = '';
+			$image_alt        = sprintf(
+									/* translators: replaced with the name of the Media Partner */
+									__( 'Website for %s', 'newspack-media-partners' ),
+									$partner->name
+								);
 			if ( $partner_image_id ) {
-				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ], false, [ 'alt' => esc_attr( $partner->name ) ] );
+				$image = wp_get_attachment_image( $partner_image_id, [ 200, 999 ], false, [ 'alt' => esc_attr( $image_alt ) ] );
 				if ( $image && $partner_url ) {
 					$image = '<a href="' . $partner_url . '" target="_blank">' . $image . '</a>';
 				}


### PR DESCRIPTION
This PR adds an alt value with the partner name to the partner logos that the plugin generates. 

When the logo doesn't have a link, it sets the alt text to the partner name.

When the logo has a link, it sets it to "Website for [partner name]" -- this is to help make the alt text more helpful in the context of the image being linked, to help tell folks who are using a screenreader that clicking the logo will bring them to that partner website. 

Close #7